### PR TITLE
Add project skeleton

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+exclude = venv

--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.10-slim
+RUN mkdir -p /app/
+WORKDIR /app
+
+COPY . .
+RUN pip3 install -r requirements.txt
+
+CMD ["python3", "main.py"]

--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ Build Docker image with:
 Then run it like this:
 
 `docker run --env BOT_TOKEN=<token> --env CHAT_ID=<chat_id> githubstatus`
+
+## Run flake8
+`flake8`
+
+## Run tests:
+`pip install -r test-requirements.txt`\
+`python -m pytest -v test/`

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # github-status
+
+## Deployment
+Build Docker image with:
+
+`docker build -f ./Dockerfile -t githubstatus .`
+
+Then run it like this:
+
+`docker run --env BOT_TOKEN=<token> --env CHAT_ID=<chat_id> githubstatus`

--- a/main.py
+++ b/main.py
@@ -1,0 +1,13 @@
+import logging
+
+from settings import Config
+from watcher.watcher import Watcher
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+if __name__ == "__main__":
+    config = Config()
+    config.load_required()
+
+    watcher = Watcher(config)
+    watcher.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+mailru-im-bot==0.0.21
+requests==2.26.0
+retry==0.9.2

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,41 @@
+import os
+from dataclasses import dataclass
+
+
+def singleton(class_):
+    instances = {}
+
+    def get_instance(*args, **kwargs):
+        if class_ not in instances:
+            instances[class_] = class_(*args, **kwargs)
+        return instances[class_]
+
+    return get_instance
+
+
+@singleton
+@dataclass
+class Config:
+    chat_id: str
+    bot_token: str
+    retry_request_delay: int
+    status_checking_interval: int
+    notification_delay: int
+    bot_api_url: str
+    github_api_url: str
+
+    def __init__(self):
+        self.retry_request_delay = int(os.environ.get("RETRY_REQUEST_DELAY", "5"))
+        self.status_checking_interval = int(os.environ.get("STATUS_CHECKING_INTERVAL", "30"))
+        self.notification_delay = int(os.environ.get("NOTIFICATION_DELAY", "120"))
+        self.bot_api_url = os.environ.get("BOT_API_URL", "https://api.internal.myteam.mail.ru/bot/v1")
+        self.github_api_url = os.environ.get("GITHUB_API_URL", "https://www.githubstatus.com/api/v2")
+
+    def load_required(self):
+        _chat_id = os.environ.get("CHAT_ID")
+        assert _chat_id, "Environment variable CHAT_ID not set."
+        self.chat_id = _chat_id
+
+        _bot_token = os.environ.get("BOT_TOKEN")
+        assert _bot_token, "Environment variable BOT_TOKEN not set."
+        self.bot_token = _bot_token

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,6 @@
+mailru-im-bot==0.0.21
+requests==2.26.0
+retry==0.9.2
+flake8==6.0.0
+requests-mock==1.10.0
+pytest==7.3.1

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,0 +1,75 @@
+import http
+import json
+
+import requests_mock
+
+from settings import Config
+from watcher.githubclient import GithubClient, BadRequestException
+
+
+class TestClient:
+
+    def test_get_status(self):
+        with requests_mock.Mocker() as mock:
+            config = Config()
+
+            expected = json.loads(
+                '{"page":{"id":"kctbh9vrtdwd","name":"GitHub","url":"https://www.githubstatus.xscom","time_zone"'
+                ':"Etc/UTC","updated_at":"2023-05-29T07:49:52.960Z"},"status":{"indicator":"none","description'
+                '":"All Systems Operational"}}')
+
+            mock.get(
+                url=f"{config.github_api_url}/status.json",
+                json=expected
+            )
+
+            response = GithubClient(api_url=config.github_api_url).get_status()
+            data = response.json()
+            assert data["status"]["indicator"].lower() == "none"
+            assert data["page"]["name"].lower() == "github"
+
+    def test_get_status_incorrect_status_code(self):
+        with requests_mock.Mocker() as mock:
+            config = Config()
+
+            mock.get(
+                url=f"{config.github_api_url}/status.json",
+                json=json.loads('{}'),
+                status_code=http.HTTPStatus.BAD_REQUEST
+            )
+            try:
+                GithubClient(api_url=config.github_api_url).get_status(retry_=False)
+            except BadRequestException:
+                return
+
+    def test_get_unresolved_incidents(self):
+        with requests_mock.Mocker() as mock:
+            config = Config()
+
+            expected = json.loads(
+                '{"page":{"id":"kctbh9vrtdwd","name":"GitHub","url":"https://www.githubstatus.com",'
+                '"time_zone":"Etc/UTC","updated_at":"2023-05-30T08:03:09.076Z"},"incidents":[]}')
+
+            mock.get(
+                url=f"{config.github_api_url}/incidents/unresolved.json",
+                json=expected
+            )
+
+            response = GithubClient(api_url=config.github_api_url).get_unresolved_incidents()
+            data = response.json()
+            assert data["incidents"] == []
+            assert data["page"]["name"].lower() == "github"
+
+    def test_get_unresolved_incidents_incorrect_status(self):
+        with requests_mock.Mocker() as mock:
+            config = Config()
+
+            mock.get(
+                url=f"{config.github_api_url}/incidents/unresolved.json",
+                json=json.loads('{}'),
+                status_code=http.HTTPStatus.BAD_REQUEST
+            )
+            try:
+                GithubClient(api_url=config.github_api_url).get_unresolved_incidents(retry_=False)
+            except BadRequestException:
+                return

--- a/test/test_incident_registry.py
+++ b/test/test_incident_registry.py
@@ -1,0 +1,40 @@
+import time
+
+from watcher.incident_registry import IncidentRegistry, Incident
+
+
+def get_incident() -> Incident:
+    return Incident(
+        component="test_component",
+        description="test_description",
+        impact="test_impact",
+        status="test_status",
+        timestamp=time.time(),
+        notified=False
+    )
+
+
+class TestIncidentRegistry:
+
+    def test_add(self):
+        incident = get_incident()
+        ir = IncidentRegistry()
+        ir.add(incident)
+        assert ir.get(incident.component) is incident
+
+    def test_list(self):
+        incident = get_incident()
+        ir = IncidentRegistry()
+        ir.add(incident)
+        ir.add(incident)
+        assert len(ir.list()) == 2
+        assert ir.list()[0] is incident
+
+    def test_clear(self):
+        incident = get_incident()
+        ir = IncidentRegistry()
+        ir.add(incident)
+        assert len(ir.list()) == 1
+
+        ir.clear()
+        assert len(ir.list()) == 0

--- a/test/test_message_formatter.py
+++ b/test/test_message_formatter.py
@@ -1,0 +1,28 @@
+import time
+
+from watcher.incident_registry import Incident
+from watcher.message_formatter import MessageFormatter
+
+
+class TestMessageFormatter:
+
+    def test_incident(self):
+        incident = Incident(
+            component="test_component",
+            description="test_description",
+            impact="test_impact",
+            status="test_status",
+            timestamp=time.time(),
+            notified=False
+        )
+        expected = "🔴 New incident\n" \
+                   "<b>Component:</b> test_component\n" \
+                   "<b>Description:</b> test_description\n" \
+                   "<b>Status:</b> test_status\n" \
+                   "<b>Impact:</b> test_impact\n"
+
+        assert MessageFormatter().incident(incident) == expected
+
+    def test_all_resolved(self):
+        expected = "🟢 All incidents resolved\n"
+        assert MessageFormatter().all_resolved() == expected

--- a/test/test_vkteamsbot.py
+++ b/test/test_vkteamsbot.py
@@ -1,0 +1,51 @@
+import http
+import json
+
+import requests_mock
+
+from settings import Config
+from watcher.vkteams_bot import VKTeamsBot, BadRequestException
+
+
+class TestVKTeamsBot:
+
+    def test_valid_request(self):
+        with requests_mock.Mocker() as mock:
+            config = Config()
+            mock.get(
+                url=f"{config.bot_api_url}/messages/sendText",
+                json=json.loads('{"msgId": "12345678", "ok": true}')
+            )
+
+            bot = VKTeamsBot(token="test_token", api_url=config.bot_api_url, chat_id="test_chat")
+            response = bot.send_message(message="test_message")
+            assert response.status_code == http.HTTPStatus.OK
+            assert response.json()["ok"] is True
+            assert response.json()["msgId"] == "12345678"
+
+    def test_incorrect_status_code(self):
+        with requests_mock.Mocker() as mock:
+            config = Config()
+            mock.get(
+                url=f"{config.bot_api_url}/messages/sendText",
+                json=json.loads('{}'),
+                status_code=http.HTTPStatus.BAD_REQUEST
+            )
+            try:
+                bot = VKTeamsBot(token="test_token", api_url=config.bot_api_url, chat_id="test_chat")
+                bot.send_message(message="test_message", retry_=False)
+            except BadRequestException:
+                return
+
+    def test_invalid_token(self):
+        with requests_mock.Mocker() as mock:
+            config = Config()
+            mock.get(
+                url=f"{config.bot_api_url}/messages/sendText",
+                json=json.loads('{"description": "Invalid token", "ok": false}')
+            )
+
+            bot = VKTeamsBot(token="test_token", api_url=config.bot_api_url, chat_id="test_chat")
+            response = bot.send_message(message="test_message", retry_=False)
+            assert response.json()["ok"] is False
+            assert response.json()["description"].lower() == "invalid token"

--- a/watcher/githubclient.py
+++ b/watcher/githubclient.py
@@ -1,0 +1,41 @@
+import http
+import logging
+from typing import Optional
+
+import requests
+import retry
+
+import settings
+
+
+class BadRequestException(Exception):
+    pass
+
+
+class GithubClient:
+
+    def __init__(self, api_url: str):
+        self.__api_url = api_url
+
+    @retry.retry(exceptions=BadRequestException, delay=settings.Config().retry_request_delay)
+    def _get_request(self, url: str, retry_: bool = True) -> Optional[requests.Response]:
+        response = requests.get(url)
+        logging.info(f"Sent request: {response.url}")
+        logging.debug(f"Response status code: {response.status_code} \njson: {response.json()}")
+        if response.status_code != http.HTTPStatus.OK:
+            logging.error(f"Incorrect status code for request: {response.url} \nResponse json: {response.json()}")
+            if retry_:
+                raise BadRequestException
+        return response
+
+    def get_summary(self, retry_: bool = True) -> Optional[requests.Response]:
+        url = f"{self.__api_url}/summary.json"
+        return self._get_request(url, retry_)
+
+    def get_status(self, retry_: bool = True) -> requests.Response:
+        url = f"{self.__api_url}/status.json"
+        return self._get_request(url, retry_)
+
+    def get_unresolved_incidents(self, retry_: bool = True) -> requests.Response:
+        url = f"{self.__api_url}/incidents/unresolved.json"
+        return self._get_request(url, retry_)

--- a/watcher/incident_registry.py
+++ b/watcher/incident_registry.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from typing import Optional, Any
+
+
+@dataclass
+class Incident:
+    component: str
+    description: str
+    impact: str
+    status: str
+    timestamp: float
+    notified: bool
+
+
+class IncidentRegistry:
+
+    def __init__(self):
+        self.registry = []
+
+    def add(self, incident: Incident):
+        self.registry.append(incident)
+
+    def delete(self, incident: Incident):
+        raise NotImplementedError
+
+    def list(self) -> list:
+        return self.registry
+
+    def clear(self):
+        self.registry.clear()
+
+    def get(self, component_name: str) -> Optional[Incident]:
+        for incident in self.registry:
+            if incident.component == component_name:
+                return incident
+        return None
+
+    def update(self, component_name: str, field: str, value: Optional[Any]):
+        for incident in self.registry:
+            if incident.component == component_name:
+                if incident.__dict__.get(field) is None:
+                    raise ValueError(f"Field with name {field} not found.")
+                incident.__dict__[field] = value
+                return
+        raise NameError(f"Component with name {component_name} not found.")

--- a/watcher/message_formatter.py
+++ b/watcher/message_formatter.py
@@ -1,0 +1,20 @@
+from watcher.incident_registry import Incident
+
+
+class MessageFormatter:
+    @staticmethod
+    def incident(incident: Incident) -> str:
+        return "🔴 New incident\n" \
+               f"<b>Component:</b> {incident.component}\n" \
+               f"<b>Description:</b> {incident.description}\n" \
+               f"<b>Status:</b> {incident.status}\n" \
+               f"<b>Impact:</b> {incident.impact}\n"
+
+    @staticmethod
+    def incident_resolved(incident: Incident):
+        return "🟢 Incident resolved\n" \
+               f"<b>Component:</b> {incident.component}\n"
+
+    @staticmethod
+    def all_resolved() -> str:
+        return "🟢 All incidents resolved\n"

--- a/watcher/vkteams_bot.py
+++ b/watcher/vkteams_bot.py
@@ -1,0 +1,38 @@
+import http
+import logging
+
+import requests
+import retry
+from bot import bot as teamsbot
+
+import settings
+
+
+class BadRequestException(Exception):
+    pass
+
+
+class VKTeamsBot:
+
+    def __init__(self, token: str, api_url: str, chat_id: str):
+        self.bot = teamsbot.Bot(token=token, api_url_base=api_url)
+        self.chat_id = chat_id
+
+    @retry.retry(exceptions=BadRequestException, delay=settings.Config().retry_request_delay)
+    def send_message(
+            self,
+            message: str,
+            chat_id: str = None,
+            parse_mode: str = "HTML",
+            retry_: bool = True) -> requests.Response:
+        if chat_id is None:
+            chat_id = self.chat_id
+
+        response = self.bot.send_text(chat_id=chat_id, text=message, parse_mode=parse_mode)
+        logging.info(f"Sent request {response.url}")
+        logging.debug(f"Response status code: {response.status_code} \njson: {response.json()}")
+        if response.status_code != http.HTTPStatus.OK or response.json()["ok"] is False:
+            logging.error(f"Incorrect status code for request: {response.url} \nResponse json: {response.json()}")
+            if retry_:
+                raise BadRequestException
+        return response

--- a/watcher/watcher.py
+++ b/watcher/watcher.py
@@ -1,0 +1,56 @@
+import time
+
+from settings import Config
+from watcher.githubclient import GithubClient
+from watcher.incident_registry import IncidentRegistry, Incident
+from watcher.message_formatter import MessageFormatter
+from watcher.vkteams_bot import VKTeamsBot
+
+
+def endless_loop_decorator(func, interval=Config().status_checking_interval):
+    def wrapper(*args, **kwargs):
+        while True:
+            func(*args, **kwargs)
+            time.sleep(interval)
+
+    return wrapper
+
+
+class Watcher:
+
+    def __init__(self, config: Config):
+        self.config = config
+        self.client = GithubClient(api_url=self.config.github_api_url)
+        self.teamsbot = VKTeamsBot(token=self.config.bot_token,
+                                   api_url=self.config.bot_api_url,
+                                   chat_id=self.config.chat_id)
+        self.incident_registry = IncidentRegistry()
+
+    @endless_loop_decorator
+    def run(self):
+        status_info = self.client.get_status().json()
+        if status_info["status"]["indicator"] != "none":
+            unresolved = self.client.get_unresolved_incidents().json()
+            if len(unresolved["incidents"]) >= 1:
+                incident_list = unresolved["incidents"]
+                component_name = incident_list[0]["components"][0]["name"]
+                if self.incident_registry.get(component_name) is None:
+                    self.incident_registry.add(
+                        Incident(
+                            component=component_name,
+                            description=incident_list[0]["name"],
+                            status=incident_list[0]["status"],
+                            impact=incident_list[0]["impact"],
+                            timestamp=time.time(),
+                            notified=False
+                        ))
+        else:
+            if self.incident_registry.list():
+                self.teamsbot.send_message(message=MessageFormatter.all_resolved())
+                self.incident_registry.clear()
+
+        for incident in self.incident_registry.list():
+            if not incident.notified:
+                if (time.time() - incident.timestamp) >= self.config.notification_delay:
+                    self.incident_registry.update(incident.component, "notified", True)
+                    self.teamsbot.send_message(message=MessageFormatter.incident(incident))


### PR DESCRIPTION
**About service**
The purpose of the `github-status` service is to send messages about incidents in _Github_ components to _VKTeams_.
The service does not have a UI. It is assumed that the service will be launched in the infrastructure and will run as a background process inside the docker container.

**The logic of the service**
The service is based on an endless loop in which the following actions are performed:
- With a specified interval (by default 30 seconds), an api request is executed to check the status of Github components
- If an incident occurs in any component, information about it is added to the internal incident registry
- If the incident is relevant for more than 2 minutes, a fail message is sent to the VKTeams channel
- If all incidents are fixed, a message is sent that everything is fixed

Closes [#166](https://github.com/tarantool/infra/issues/166)